### PR TITLE
Improve logging and debugging for Mercado Livre Selenium test

### DIFF
--- a/test_selenium_ml.py
+++ b/test_selenium_ml.py
@@ -17,24 +17,35 @@ def main() -> None:
     options.add_argument("--headless=new")
 
     driver = None
+    selector = "li.ui-search-layout__item a.ui-search-link"
     try:
+        print(f"Acessando URL: {url}")
         driver = webdriver.Chrome(options=options)
+        print("Página carregada, aguardando resultados...")
         driver.get(url)
 
-        wait = WebDriverWait(driver, 10)
+        wait = WebDriverWait(driver, 20)
         element = wait.until(
-            EC.presence_of_element_located(
-                (By.CSS_SELECTOR, "li.ui-search-layout__item a.ui-search-link")
-            )
+            EC.presence_of_element_located((By.CSS_SELECTOR, selector))
         )
+        elements = driver.find_elements(By.CSS_SELECTOR, selector)
+        print(f"Quantidade de produtos encontrados: {len(elements)}")
         link = element.get_attribute("href")
         print(f"Primeiro link encontrado: {link}")
     except TimeoutException:
         print("Erro: nenhum produto encontrado dentro do tempo limite.")
+        if driver:
+            try:
+                screenshot = "timeout.png"
+                driver.save_screenshot(screenshot)
+                print(f"Screenshot salva em {screenshot}")
+            except WebDriverException as err:
+                print(f"Falha ao salvar screenshot: {err}")
     except WebDriverException as exc:
         print(f"Erro ao iniciar o ChromeDriver ou acessar a página: {exc}")
     finally:
         if driver:
+            print("Fechando o driver")
             driver.quit()
         total = time.time() - start
         print(f"Tempo total de execução: {total:.2f} segundos")


### PR DESCRIPTION
## Summary
- enhance Mercado Livre Selenium test with more detailed logging and a longer wait time for results
- capture a screenshot on timeout to help debug missing products

## Testing
- `python test_selenium_ml.py` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_689406e7b62c832bbdb037c229266052